### PR TITLE
Update session.py

### DIFF
--- a/session.py
+++ b/session.py
@@ -1,3 +1,4 @@
+import re
 import requests
 from bs4 import BeautifulSoup
 import pandas as pd
@@ -22,11 +23,11 @@ class httpIMDB():
         posters_src = [rf"{poster.img['src']}" for poster in posters]
         
         titles = html.find_all('td', class_='titleColumn')
-        titles_name = [rf'{title.a.text} {title.span.text}' for title in titles]
+        titles_name = [rf'{title.a.get_text()} {title.span.get_text()}' for title in titles]
         ids = [title.a['href'].split('/')[2] for title in titles]
 
         ratings = html.find_all('td', class_='ratingColumn imdbRating')
-        ratings_score = [rating.strong.text if rating.strong else 'None' for rating in ratings]
+        ratings_score = [rating.strong.get_text() if rating.strong else 'None' for rating in ratings]
 
         out_dict = {
             'Id': ids,
@@ -69,17 +70,17 @@ class httpIMDB():
 
         # sinapse
         try:
-            sinapse = html.find('span', class_ = 'GenresAndPlot__TextContainerBreakpointXL-sc-cum89p-2').text 
+            sinapse = html.find('span', class_ = 'GenresAndPlot__TextContainerBreakpointXL-sc-cum89p-2').get_text() 
         except AttributeError:
-            sinapse = html.find('span', class_ = 'GenresAndPlot__TextContainerBreakpointXL-sc-cum89p-1').text
+            sinapse = html.find('span', class_ = 'GenresAndPlot__TextContainerBreakpointXL-sc-cum89p-1').get_text()
 
         # genres
         genre_div = html.find('div', class_='GenresAndPlot__GenresChipList-sc-cum89p-4')
-        genres = [a_tag.span.text for a_tag in genre_div]
+        genres = [a_tag.span.get_text() for a_tag in genre_div]
 
         # types
         ul_types = html.find('ul', class_='TitleBlockMetaData__MetaDataList-sc-12ein40-0')
-        li_types = [li.a.text if li.find('a', recursive=False) else li.text for li in ul_types.children]
+        li_types = [li.a.get_text() if li.find('a', recursive=False) else li.get_text() for li in ul_types.children]
 
         # top_casts = html.find('div', class_='ipc-sub-grid ipc-sub-grid--page-span-2 ipc-sub-grid--wsraps-at-above-l ipc-shoveler__grid')
 
@@ -99,18 +100,43 @@ class httpIMDB():
                     else:
                         new_actor['avatar'] = section.div.div.img['src']
                 elif idx == 1:
-                    new_actor['name'] = section.a .text
-                    new_actor['character'] = section.div.ul.li.a.span.text
+                    new_actor['name'] = section.a .get_text()
+                    new_actor['character'] = section.div.ul.li.a.span.get_text()
             
             top_cast.append(new_actor)
 
 
-        title = html.find('h1', class_='TitleHeader__TitleText-sc-1wu6n3d-0').text
+        title = html.find('h1', class_='TitleHeader__TitleText-sc-1wu6n3d-0').get_text()
 
-        rating = html.find('span', class_='AggregateRatingButton__RatingScore-sc-1ll29m0-1').text
+        rating = html.find('span', class_='AggregateRatingButton__RatingScore-sc-1ll29m0-1').get_text()
 
-        popularity = html.find('div', class_='TrendingButton__TrendingScore-sc-bb3vt8-1').text
-
+        popularity = html.find('div', class_='TrendingButton__TrendingScore-sc-bb3vt8-1').get_text()
+        
+        # while .text works, .get_text() is properly documented and so used as best practice
+        runtime = html.find('li', {"data-testid":"title-techspec_runtime"})
+        runtime_str = runtime.find('div').get_text()
+        hours = re.search("(?P<hours>\d*) hours?", runtime.get_text())
+        minutes = re.search("(?P<minutes>\d*) minutes?", runtime.get_text())
+        
+        # processing some times with ridiculous lengths, see https://www.imdb.com/title/tt3854496
+        # this would be set to 59, except some films report a 60 minute runtime
+        if int(minutes[1]) >60:
+            # commas present an issue for ints, _ retained for readability
+            if int(minutes[1])>999:
+                max_minutes = minutes[1].replace(',', "_")
+            else:
+                max_minutes = minutes[1]
+            sum_hours = int(max_minutes) // 60
+            minutes = int(max_minutes) % 60
+            hours = int(hours[1].replace(',', "_")) + sum_hours
+        else:
+            minutes = int(minutes[1])
+            # couldn't find anything with over 720 hours of content, but in any case...
+            hours = int(hours[1].replace(',', "_"))
+        
+        # duration is tuple of integers for the hours and minutes
+        duration = (hours, minutes)
+        
 
         output_dict = { 
             'title': title,
@@ -118,6 +144,8 @@ class httpIMDB():
             'sinapse':sinapse,
             'rating': str(rating),
             'popularity': str(popularity),
+            'runtime' : runtime_str, # pulled directly from html string on page
+            'duration' : duration, # calculated above
             # 'stars': stars,
             'genres': genres,
             'types': li_types,
@@ -134,7 +162,7 @@ class httpIMDB():
         html = BeautifulSoup(response.text, 'html.parser')
 
         titles_tag = html.findAll('td', class_='result_text')
-        titles = [t.a.text for t in titles_tag]
+        titles = [t.a.get_text() for t in titles_tag]
         ids = [t.a['href'].split('/')[2] for t in titles_tag]
         
         return pd.DataFrame({'Id': ids, 'Title': titles})

--- a/session.py
+++ b/session.py
@@ -120,17 +120,25 @@ class httpIMDB():
         
         # processing some times with ridiculous lengths, see https://www.imdb.com/title/tt3854496
         # this would be set to 59, except some films report a 60 minute runtime
-        if int(minutes[1]) >60:
-            # commas present an issue for ints, _ retained for readability
-            if int(minutes[1])>999:
-                max_minutes = minutes[1].replace(',', "_")
-            else:
-                max_minutes = minutes[1]
-            sum_hours = int(max_minutes) // 60
+        
+        # catching cases where minutes is None
+        try:
+            sum_hours = 0
+            max_minutes = int(minutes[1])
+            if int(minutes[1]) > 60:
+                # commas present an issue for ints, _ retained for readability
+                if int(minutes[1]) > 999:
+                    max_minutes = minutes[1].replace(',', "_")
+                else:
+                    max_minutes = minutes[1]
+                sum_hours = int(max_minutes) // 60
+
+            # this is valid for any case (minutes is greater or less than 60)
+            # 22 % 60 = 22
             minutes = int(max_minutes) % 60
             hours = int(hours[1].replace(',', "_")) + sum_hours
-        else:
-            minutes = int(minutes[1])
+        except TypeError:
+            minutes = int(0)
             # couldn't find anything with over 720 hours of content, but in any case...
             hours = int(hours[1].replace(',', "_"))
         
@@ -144,12 +152,11 @@ class httpIMDB():
             'sinapse':sinapse,
             'rating': str(rating),
             'popularity': str(popularity),
-            'runtime' : runtime_str, # pulled directly from html string on page
-            'duration' : duration, # calculated above
-            # 'stars': stars,
-            'genres': genres,
-            'types': li_types,
-            'top_cast': pd.DataFrame(top_cast)
+            'runtime' : [runtime_str], # pulled directly from html string on page
+            'duration' : [duration], # calculated above
+            'genres': [genres],
+            'types': [li_types],
+            'top_cast': [top_cast]
         }
 
         return pd.DataFrame(output_dict)
@@ -166,4 +173,3 @@ class httpIMDB():
         ids = [t.a['href'].split('/')[2] for t in titles_tag]
         
         return pd.DataFrame({'Id': ids, 'Title': titles})
-


### PR DESCRIPTION
Incorporated runtime data into getTitleDetails. 
- Pulls hours/minutes runtimes with BeautifulSoup then two Regexes.
- Does some limited error correction and calculation for extremely long materials.
- Nothing was found in the IMDB library with a runtime shorter than 1 minute.
- Adds a key 'runtime' that returns a string pulled directly from the page's html description of its runtime.
- Adds a key 'duration' that is a tuple of integers, [0] is hours, [1] is minutes. 
- Replaces instances of .text in BeautifulSoup methods to get_text() as this is properly documented.
-- This was done by hand due to instances of requests.response objects using a .text method to return html pages.

- Note that this has not been fully tested.